### PR TITLE
fix: 집 노트, 쉬운 계약서 첨부 이미지 제거 쿼리 오류 해결

### DIFF
--- a/src/main/java/com/dojangkok/backend/auth/oauth/handler/OAuth2LoginSuccessHandler.java
+++ b/src/main/java/com/dojangkok/backend/auth/oauth/handler/OAuth2LoginSuccessHandler.java
@@ -2,6 +2,7 @@ package com.dojangkok.backend.auth.oauth.handler;
 
 import com.dojangkok.backend.auth.token.RedisExchangeCodeStore;
 import com.dojangkok.backend.auth.token.RedisExchangeCodeStore.ExchangeData;
+import com.dojangkok.backend.repository.MemberRepository;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
@@ -28,6 +29,7 @@ import java.util.UUID;
 public class OAuth2LoginSuccessHandler implements AuthenticationSuccessHandler {
 
     private final RedisExchangeCodeStore exchangeCodeStore;
+    private final MemberRepository memberRepository;
 
     @Value("${app.oauth2.success-redirect}")
     private String successRedirect;
@@ -39,13 +41,14 @@ public class OAuth2LoginSuccessHandler implements AuthenticationSuccessHandler {
 
         DefaultOAuth2User principal = (DefaultOAuth2User) authentication.getPrincipal();
         Long memberId = ((Number) Objects.requireNonNull(principal).getAttributes().get("memberId")).longValue();
+        boolean isNicknameExists = isNicknameExists(memberId);
         boolean isNewUser = (Boolean) principal.getAttributes().get("isNewUser");
 
         log.info("memberId: {}, isNewUser: {}", memberId, isNewUser);
 
         // 일회성 교환 코드 생성
         String exchangeCode = UUID.randomUUID().toString();
-        exchangeCodeStore.save(exchangeCode, new ExchangeData(memberId, isNewUser));
+        exchangeCodeStore.save(exchangeCode, new ExchangeData(memberId, isNicknameExists, isNewUser));
 
         log.info("교환 코드 저장 완료: {}", exchangeCode);
 
@@ -58,5 +61,9 @@ public class OAuth2LoginSuccessHandler implements AuthenticationSuccessHandler {
         log.info("리다이렉트 URL: {}", redirectUrl);
 
         response.sendRedirect(redirectUrl);
+    }
+
+    private boolean isNicknameExists(Long memberId) {
+        return memberRepository.existsNicknameById(memberId);
     }
 }

--- a/src/main/java/com/dojangkok/backend/auth/oauth/service/CustomOAuth2UserService.java
+++ b/src/main/java/com/dojangkok/backend/auth/oauth/service/CustomOAuth2UserService.java
@@ -33,6 +33,9 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
     private final SocialAuthRepository socialAuthRepository;
     private final MemberRepository memberRepository;
 
+    /**
+     * 카카오 서버로부터 사용자 정보 받음
+     */
     @Override
     public OAuth2User loadUser(OAuth2UserRequest req) throws OAuth2AuthenticationException {
         OAuth2User oAuth2User = super.loadUser(req);

--- a/src/main/java/com/dojangkok/backend/auth/token/RedisExchangeCodeStore.java
+++ b/src/main/java/com/dojangkok/backend/auth/token/RedisExchangeCodeStore.java
@@ -57,6 +57,7 @@ public class RedisExchangeCodeStore {
 
     public record ExchangeData(
             Long memberId,
+            boolean isNicknameExists,
             boolean isNewUser
     ) {}
 }

--- a/src/main/java/com/dojangkok/backend/common/enums/Code.java
+++ b/src/main/java/com/dojangkok/backend/common/enums/Code.java
@@ -51,6 +51,8 @@ public enum Code {
     EASY_CONTRACT_ACCESS_DENIED(HttpStatus.FORBIDDEN.value(), "EASY_CONTRACT_ACCESS_DENIED", "해당 쉬운 계약서에 대한 권한이 없습니다."),
     EASY_CONTRACT_TITLE_EMPTY(HttpStatus.BAD_REQUEST.value(), "EASY_CONTRACT_TITLE_EMPTY", "쉬운 계약서의 제목이 비어있습니다."),
     EASY_CONTRACT_TITLE_TOO_LONG(HttpStatus.UNPROCESSABLE_CONTENT.value(), "EASY_CONTRACT_TITLE_TOO_LONG", "쉬운 계약서 제목의 최대 길이를 초과하였습니다."),
+    EASY_CONTRACT_FILE_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "EASY_CONTRACT_FILE_NOT_FOUND", "해당 파일이 존재하지 않습니다."),
+    EASY_CONTRACT_FILE_RELATION_CONFLICT(HttpStatus.CONFLICT.value(), "EASY_CONTRACT_FILE_RELATION_CONFLICT", "해당 파일이 쉬운 계약서에 포함되어 있지 않습니다."),
 
     // AI 서비스 관련 오류
     AI_SERVICE_ERROR(HttpStatus.BAD_GATEWAY.value(), "AI_SERVICE_ERROR", "AI 서비스에서 오류가 발생하였습니다."),

--- a/src/main/java/com/dojangkok/backend/controller/EasyContractController.java
+++ b/src/main/java/com/dojangkok/backend/controller/EasyContractController.java
@@ -62,4 +62,10 @@ public class EasyContractController {
         easyContractService.deleteEasyContract(memberId, easyContractId);
         return ResponseEntity.noContent().build();
     }
+
+    @DeleteMapping("/{easyContractId}/files/{fileAssetId}")
+    public ResponseEntity<Void> deleteEasyContractFile(@CurrentMemberId Long memberId, @PathVariable Long easyContractId, @PathVariable Long fileAssetId) {
+        easyContractService.deleteEasyContractFile(memberId, easyContractId, fileAssetId);
+        return ResponseEntity.noContent().build();
+    }
 }

--- a/src/main/java/com/dojangkok/backend/controller/HomeNoteController.java
+++ b/src/main/java/com/dojangkok/backend/controller/HomeNoteController.java
@@ -61,14 +61,13 @@ public class HomeNoteController {
         return new DataResponseDto<>(Code.SUCCESS, "집 노트 이미지가 성공적으로 첨부되었습니다.", responseDto);
     }
 
-    @DeleteMapping("/{homeNoteId}/file/{fileId}")
-    public ResponseEntity<Void> deleteHomeNoteFile(@CurrentMemberId Long memberId, @PathVariable Long homeNoteId,
-                                                   @PathVariable Long fileId) {
+    @DeleteMapping("/{homeNoteId}/files/{fileId}")
+    public ResponseEntity<Void> deleteHomeNoteFile(@CurrentMemberId Long memberId, @PathVariable Long homeNoteId, @PathVariable Long fileId) {
         homeNoteService.deleteHomeNoteFile(memberId, homeNoteId, fileId);
         return ResponseEntity.noContent().build();
     }
 
-    @GetMapping("/checklists/template")
+    @GetMapping("/checklists/templates")
     public DataResponseDto<ChecklistTemplateResponseDto> getChecklistTemplate(@CurrentMemberId Long memberId) {
         ChecklistTemplateResponseDto responseDto = checklistService.getChecklistTemplate(memberId);
         return new DataResponseDto<>(Code.SUCCESS, "체크리스트 템플릿 조회에 성공하였습니다.", responseDto);

--- a/src/main/java/com/dojangkok/backend/dto/auth/TokenExchangeResponseDto.java
+++ b/src/main/java/com/dojangkok/backend/dto/auth/TokenExchangeResponseDto.java
@@ -16,6 +16,9 @@ public class TokenExchangeResponseDto {
     @JsonProperty("expires_in")
     private int expiresIn;
 
+    @JsonProperty("is_nickname_exists")
+    private boolean nicknameExists;
+
     @JsonProperty("is_new_user")
     private boolean newUser;
 }

--- a/src/main/java/com/dojangkok/backend/repository/EasyContractFileRepository.java
+++ b/src/main/java/com/dojangkok/backend/repository/EasyContractFileRepository.java
@@ -26,4 +26,6 @@ public interface EasyContractFileRepository extends JpaRepository<EasyContractFi
 
     @Query("SELECT MAX(ecf.sortOrder) FROM EasyContractFile ecf WHERE ecf.easyContract.id = :easyContractId")
     Optional<Integer> findMaxSortOrderByEasyContractId(@Param("easyContractId") Long easyContractId);
+
+    Optional<EasyContractFile> findByFileAssetIdAndEasyContractId(Long id, Long easyContractId);
 }

--- a/src/main/java/com/dojangkok/backend/repository/HomeNoteFileRepository.java
+++ b/src/main/java/com/dojangkok/backend/repository/HomeNoteFileRepository.java
@@ -49,7 +49,5 @@ public interface HomeNoteFileRepository extends JpaRepository<HomeNoteFile, Long
     @Query("SELECT MAX(hnf.sortOrder) FROM HomeNoteFile hnf WHERE hnf.homeNote.id = :homeNoteId")
     Optional<Integer> findMaxSortOrderByHomeNoteId(@Param("homeNoteId") Long homeNoteId);
 
-    Optional<HomeNoteFile> findByIdAndHomeNoteId(Long id, Long homeNoteId);
-
-    boolean existsByFileAssetId(Long fileAssetId);
+    Optional<HomeNoteFile> findByFileAssetIdAndHomeNoteId(Long id, Long homeNoteId);
 }

--- a/src/main/java/com/dojangkok/backend/repository/MemberRepository.java
+++ b/src/main/java/com/dojangkok/backend/repository/MemberRepository.java
@@ -8,4 +8,5 @@ import org.springframework.stereotype.Repository;
 public interface MemberRepository extends JpaRepository<Member, Long> {
 
     boolean existsByNickname(String nickname);
+    boolean existsNicknameById(Long memberId);
 }

--- a/src/main/java/com/dojangkok/backend/service/AuthService.java
+++ b/src/main/java/com/dojangkok/backend/service/AuthService.java
@@ -33,6 +33,7 @@ public class AuthService {
                 .orElseThrow(() -> new GeneralException(Code.INVALID_EXCHANGE_CODE));
 
         Long memberId = data.memberId();
+        boolean isNicknameExists = data.isNicknameExists();
         boolean isNewUser = data.isNewUser();
 
         String accessToken = jwtProvider.createAccessToken(memberId);
@@ -43,6 +44,7 @@ public class AuthService {
         TokenExchangeResponseDto token = TokenExchangeResponseDto.builder()
                 .accessToken(accessToken)
                 .expiresIn(jwtProvider.getAccessExpMin() * 60)
+                .nicknameExists(isNicknameExists)
                 .newUser(isNewUser)
                 .build();
 

--- a/src/main/java/com/dojangkok/backend/service/EasyContractService.java
+++ b/src/main/java/com/dojangkok/backend/service/EasyContractService.java
@@ -174,6 +174,23 @@ public class EasyContractService {
         log.info("EasyContract deleted: id={}, memberId={}", easyContractId, memberId);
     }
 
+    @Transactional
+    public void deleteEasyContractFile(Long memberId, Long easyContractId, Long fileAssetId) {
+        getEasyContractWithAccessCheck(memberId, easyContractId);
+
+        EasyContractFile easyContractFile = easyContractFileRepository.findByFileAssetIdAndEasyContractId(fileAssetId, easyContractId)
+                .orElseThrow(() -> new GeneralException(Code.EASY_CONTRACT_FILE_NOT_FOUND));
+
+        // FileAsset soft delete (배치 작업에서 S3 파일 삭제 예정)
+        FileAsset fileAsset = easyContractFile.getFileAsset();
+        fileAsset.softDelete();
+
+        // EasyContractFile hard delete
+        easyContractFileRepository.delete(easyContractFile);
+
+        log.info("EasyContractFile deleted: fileAssetId={}, easyContractId={}, fileAssetId={}", fileAssetId, easyContractId, fileAsset.getId());
+    }
+
     private String createTitle(Long memberId) {
         int completedCount = easyContractRepository.countCompletedByMemberId(memberId);
         return TITLE_PREFIX + (completedCount + 1);


### PR DESCRIPTION
### Description

<!--
  간단하게 PR의 목적을 설명하세요.
  이 PR이 해결하려는 문제나 추가하려는 기능에 대해 요약해주세요.
-->

repository에서 집 노트, 쉬운 계약서에 첨부된 이미지를 찾는 쿼리 오류 해결

### Related Issues

<!--
  관련된 이슈 번호를 참고하세요.
  예: Fixes #123, Closes #456
-->
- Resolves #[이슈 번호]

### Changes Made

<!--
  이 PR에서 변경된 사항을 설명하세요.
  코드, 문서, 설정 등 변경된 내용을 상세히 기술합니다.
-->

1. HomeNoteFileRepository file_asset_id, home_note_id 기반으로 jpa 메서드 네이밍 변경
- `findByFileAssetIdAndHomeNoteId`
2. EasyContractFileRepository file_asset_id, easy_contract_id jpa 메서드 네이밍 변경
- `findByFileAssetIdAndEasyContractId`

### Screenshots or Video

<!--
  변경된 사항이 UI에 영향을 미치는 경우, 변경 전후의 스크린샷이나 동영상을 첨부하세요.
-->

### Testing

<!--
  변경 사항을 테스트한 방법을 설명하세요.
  테스트한 환경 (OS, 브라우저, 장치 등)과 테스트 절차를 구체적으로 기술합니다.
-->

1. [테스트 1]
4. [테스트 2]
5. [테스트 3]

### Checklist

<!--
  PR 작성 시 다음 항목들을 확인하세요.
-->

- [ ] 코드가 정상적으로 컴파일되는지 확인했습니다.
- [ ] 모든 테스트가 성공적으로 통과했습니다.
- [ ] 관련 문서를 업데이트했습니다.
- [ ] PR이 관련 이슈를 정확히 참조하고 있습니다.
- [ ] 코드 스타일 가이드라인을 준수했습니다.
- [ ] 코드 리뷰어를 지정했습니다.

### Additional Notes

<!--
  리뷰어가 이해하는 데 도움이 될 추가적인 참고 사항이나 정보가 있다면 여기에 작성하세요.
-->

